### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://jomofisher.visualstudio.com/70eb85f9-4266-4e20-b167-979f1404880e/9fc5c8e8-6951-47fb-9adc-197e5ef77e68/_apis/work/boardbadge/d22a2c64-08f7-4259-88d7-9e43852bd27a)](https://jomofisher.visualstudio.com/70eb85f9-4266-4e20-b167-979f1404880e/_boards/board/t/9fc5c8e8-6951-47fb-9adc-197e5ef77e68/Microsoft.RequirementCategory)
 [![Build Status](https://travis-ci.org/jomof/cmake-server-java-bindings.svg?branch=master)](https://travis-ci.org/jomof/cmake-server-java-bindings)
 [![](https://jitpack.io/v/com.jomofisher/cmake-server-java-bindings.svg)](https://jitpack.io/#com.jomofisher/cmake-server-java-bindings)
 [![codecov](https://codecov.io/gh/jomof/cmake-server-java-bindings/branch/master/graph/badge.svg)](https://codecov.io/gh/jomof/cmake-server-java-bindings)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://jomofisher.visualstudio.com/70eb85f9-4266-4e20-b167-979f1404880e/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.